### PR TITLE
Improve portfolio navigation with categories

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -7,6 +7,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
 import ProjectDetailPage from './pages/ProjectDetailPage';
+import PortfolioPage from './pages/PortfolioPage';
 import ArtDetailPage from './pages/ArtDetailPage';
 import ContactPage from './pages/ContactPage';
 import LoginPage from './pages/LoginPage';
@@ -52,6 +53,7 @@ export default function App() {
         <main className="page-transition loaded">
           <Routes>
             <Route path="/" element={<HomePage />} />
+            <Route path="/category/:slug" element={<PortfolioPage />} />
             <Route path="/project/:slug" element={<ProjectDetailPage />} />
             <Route path="/art/:id" element={<ArtDetailPage />} />
             <Route path="/contact" element={<ContactPage />} />

--- a/web/src/components/CategoryCard.js
+++ b/web/src/components/CategoryCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+
+export default function CategoryCard({ category, index }) {
+  return (
+    <motion.div
+      className="project-card"
+      data-aos="fade-up"
+      data-aos-delay={`${index}00`}
+      whileHover={{ y: -8 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Link to={`/category/${category.slug}`} className="project-link">
+        <div className="project-image">
+          {category.image ? (
+            <img src={category.image} alt={category.name} loading="lazy" />
+          ) : (
+            <div style={{ padding: '1rem' }}>No image</div>
+          )}
+        </div>
+        <div className="project-overlay">
+          <h2 className="project-title">{category.name}</h2>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}

--- a/web/src/pages/HomePage.js
+++ b/web/src/pages/HomePage.js
@@ -1,56 +1,60 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import ProjectCard from '../components/ProjectCard';
+import CategoryCard from '../components/CategoryCard';
 import { apiService, handleApiError } from '../services/api';
 
 export default function HomePage() {
-  const [projects, setProjects] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetchProjects();
+    fetchCategories();
   }, []);
 
-  const fetchProjects = async () => {
+  const fetchCategories = async () => {
     try {
-      const response = await apiService.getProjects();
-      // Transform images to project format for backward compatibility
-      const projectData = Array.isArray(response.data) ? response.data : (response.data.data || []);
-      const transformedProjects = projectData.map(image => ({
-        id: image.id,
-        title: image.title,
-        image: image.thumbnailUrl || image.url,
-        description: image.description
+      const response = await apiService.getCategories();
+      const categoryData = Array.isArray(response.data?.data)
+        ? response.data.data
+        : Array.isArray(response.data)
+        ? response.data
+        : [];
+      const transformed = categoryData.map(cat => ({
+        id: cat.id,
+        name: cat.name,
+        slug: cat.slug,
+        image: cat.coverImageUrl,
+        description: cat.description,
       }));
-      setProjects(transformedProjects);
+      setCategories(transformed);
     } catch (err) {
-      console.error('Failed to fetch projects:', err);
+      console.error('Failed to fetch categories:', err);
       setError(handleApiError(err));
-      
+
       // Fallback to demo data if API not available
-      setProjects([
+      setCategories([
         {
-          id: 1,
-          title: 'Digital Art Collection',
-          slug: 'digital-art-collection',
+          id: '1',
+          name: 'Tattoo Art',
+          slug: 'tattoo-art',
           image: 'https://picsum.photos/400/300?random=1',
-          description: 'A collection of digital artwork'
+          description: 'Tattoo photography and artwork',
         },
         {
-          id: 2,
-          title: 'Portrait Series',
-          slug: 'portrait-series',
+          id: '2',
+          name: 'Art Photography',
+          slug: 'art-photography',
           image: 'https://picsum.photos/400/300?random=2',
-          description: 'Contemporary portrait series'
+          description: 'Artistic photography and visual art',
         },
         {
-          id: 3,
-          title: 'Abstract Expressions',
-          slug: 'abstract-expressions',
+          id: '3',
+          name: 'Digital Art',
+          slug: 'digital-art',
           image: 'https://picsum.photos/400/300?random=3',
-          description: 'Abstract art expressions'
-        }
+          description: 'Digital artwork and illustrations',
+        },
       ]);
     } finally {
       setLoading(false);
@@ -68,7 +72,7 @@ export default function HomePage() {
   if (error) {
     return (
       <div className="error-message">
-        <h2>Error loading projects</h2>
+        <h2>Error loading categories</h2>
         <p>{error}</p>
       </div>
     );
@@ -104,16 +108,12 @@ export default function HomePage() {
         </div>
       </motion.div>
 
-      {/* Projects Grid */}
+      {/* Categories Grid */}
       <div className="projects-grid">
-        {Array.isArray(projects) && projects.map((project, index) => (
-          <ProjectCard 
-            key={project.id} 
-            project={project} 
-            index={index}
-          />
+        {Array.isArray(categories) && categories.map((cat, index) => (
+          <CategoryCard key={cat.id} category={cat} index={index} />
         ))}
       </div>
     </div>
   );
-} 
+}

--- a/web/src/pages/PortfolioPage.js
+++ b/web/src/pages/PortfolioPage.js
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Grid, Card } from '../components/ArtCard';
 import { apiService, handleApiError } from '../services/api';
 
 export default function PortfolioPage() {
+  const { slug } = useParams();
+
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [images, setImages] = useState([]);
@@ -27,28 +30,43 @@ export default function PortfolioPage() {
       const response = await apiService.getCategories();
       
       if (response.data && response.data.success && Array.isArray(response.data.data)) {
-        setCategories(response.data.data);
+        const cats = response.data.data;
+        setCategories(cats);
+        if (slug) {
+          const found = cats.find((c) => c.slug === slug);
+          if (found) setSelectedCategory(found);
+        }
       } else {
         console.error('Failed to fetch categories:', response.data?.error || 'Invalid response format');
         setError('Failed to load categories');
         
         // Fallback to demo categories
-        setCategories([
+        const fallbackCats = [
           { id: '1', name: 'Tattoo Art', slug: 'tattoo-art', description: 'Tattoo photography and artwork' },
           { id: '2', name: 'Art Photography', slug: 'art-photography', description: 'Artistic photography and visual art' },
           { id: '3', name: 'Digital Art', slug: 'digital-art', description: 'Digital artwork and illustrations' }
-        ]);
+        ];
+        setCategories(fallbackCats);
+        if (slug) {
+          const found = fallbackCats.find((c) => c.slug === slug);
+          if (found) setSelectedCategory(found);
+        }
       }
     } catch (err) {
       console.error('Failed to fetch categories:', err);
       setError(handleApiError(err));
       
       // Fallback to demo categories
-      setCategories([
+      const fallbackCats = [
         { id: '1', name: 'Tattoo Art', slug: 'tattoo-art', description: 'Tattoo photography and artwork' },
         { id: '2', name: 'Art Photography', slug: 'art-photography', description: 'Artistic photography and visual art' },
         { id: '3', name: 'Digital Art', slug: 'digital-art', description: 'Digital artwork and illustrations' }
-      ]);
+      ];
+      setCategories(fallbackCats);
+      if (slug) {
+        const found = fallbackCats.find((c) => c.slug === slug);
+        if (found) setSelectedCategory(found);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- include cover image URLs in the `GetCategories` API
- show portfolio categories on the home page
- add `CategoryCard` component for category previews
- allow opening categories via `/category/:slug`
- initialize selected category when visiting category pages

## Testing
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bf7e67f30832e87e98ef0e66a5a4f