### PR TITLE
Improve category handling and remove demo data

### DIFF
--- a/api/GetCategories/index.js
+++ b/api/GetCategories/index.js
@@ -3,6 +3,7 @@
  */
 
 const databaseService = require('../shared/database');
+const blobStorageService = require('../shared/blobStorage');
 const { defaultCategories } = require('../shared/models');
 
 module.exports = async function (context, req) {
@@ -12,16 +13,43 @@ module.exports = async function (context, req) {
     // Get all categories from database
     const categories = await databaseService.getCategories();
 
-    // Transform categories for frontend
-    const transformedCategories = categories.map(category => ({
-      id: category.id,
-      name: category.name,
-      slug: category.slug,
-      description: category.description,
-      order: category.order,
-      isActive: category.isActive,
-      imageCount: 0 // Will be populated by a separate call if needed
-    }));
+    // Transform categories for frontend and include cover image URL
+    const transformedCategories = [];
+    for (const category of categories) {
+      let coverImageUrl = null;
+
+      try {
+        if (category.coverImageId) {
+          const img = await databaseService.getImageById(category.coverImageId);
+          if (img) {
+            coverImageUrl =
+              blobStorageService.getThumbnailUrl(img.thumbnailBlobName) ||
+              blobStorageService.getImageUrl(img.blobName);
+          }
+        } else {
+          const imgs = await databaseService.getImagesByCategory(category.id);
+          if (imgs.length > 0) {
+            const randomImg = imgs[Math.floor(Math.random() * imgs.length)];
+            coverImageUrl =
+              blobStorageService.getThumbnailUrl(randomImg.thumbnailBlobName) ||
+              blobStorageService.getImageUrl(randomImg.blobName);
+          }
+        }
+      } catch (err) {
+        context.log.warn('Failed to fetch cover image for category', category.id, err.message);
+      }
+
+      transformedCategories.push({
+        id: category.id,
+        name: category.name,
+        slug: category.slug,
+        description: category.description,
+        order: category.order,
+        isActive: category.isActive,
+        coverImageUrl,
+        imageCount: 0,
+      });
+    }
 
     context.res = {
       status: 200,
@@ -57,6 +85,7 @@ module.exports = async function (context, req) {
         description: cat.description,
         order: cat.order,
         isActive: true,
+        coverImageUrl: null,
         imageCount: 0
       }));
 

--- a/api/GetImage/index.js
+++ b/api/GetImage/index.js
@@ -79,23 +79,7 @@ module.exports = async function (context, req) {
                            error.code === 'ECONNREFUSED';
     
     if (isDatabaseError) {
-      context.log.warn('Database connection failed, returning demo image');
-      
-      // Return demo image as fallback
-      const demoImage = {
-        id: req.params.id,
-        title: 'Demo Artwork',
-        description: 'This is a demo image while the database is unavailable',
-        categoryId: 'demo-category',
-        url: `https://picsum.photos/800/600?random=${req.params.id}`,
-        thumbnailUrl: `https://picsum.photos/400/400?random=${req.params.id}`,
-        width: 800,
-        height: 600,
-        tags: ['demo'],
-        isFeatured: false,
-        order: 1,
-        createdAt: new Date().toISOString()
-      };
+      context.log.warn('Database connection failed, returning no image data');
 
       context.res = {
         status: 200,
@@ -105,7 +89,7 @@ module.exports = async function (context, req) {
         },
         body: {
           success: true,
-          data: demoImage
+          data: null
         }
       };
     } else {

--- a/api/GetImages/index.js
+++ b/api/GetImages/index.js
@@ -99,53 +99,7 @@ module.exports = async function (context, req) {
                            error.code === 'ECONNREFUSED';
     
     if (isDatabaseError) {
-      context.log.warn('Database connection failed, returning demo images');
-      
-      // Return demo images as fallback
-      const demoImages = [
-        {
-          id: 'demo-1',
-          title: 'Featured Artwork',
-          description: 'Beautiful artistic creation',
-          categoryId: 'default-1',
-          url: 'https://picsum.photos/800/600?random=1',
-          thumbnailUrl: 'https://picsum.photos/400/400?random=1',
-          width: 800,
-          height: 600,
-          tags: ['demo'],
-          isFeatured: true,
-          order: 1,
-          createdAt: new Date().toISOString()
-        },
-        {
-          id: 'demo-2',
-          title: 'Creative Expression', 
-          description: 'Inspiring visual art piece',
-          categoryId: 'default-2',
-          url: 'https://picsum.photos/800/600?random=2',
-          thumbnailUrl: 'https://picsum.photos/400/400?random=2',
-          width: 800,
-          height: 600,
-          tags: ['demo'],
-          isFeatured: true,
-          order: 2,
-          createdAt: new Date().toISOString()
-        },
-        {
-          id: 'demo-3',
-          title: 'Artistic Vision',
-          description: 'Captivating creative work',
-          categoryId: 'default-3',
-          url: 'https://picsum.photos/800/600?random=3',
-          thumbnailUrl: 'https://picsum.photos/400/400?random=3',
-          width: 800,
-          height: 600,
-          tags: ['demo'],
-          isFeatured: true,
-          order: 3,
-          createdAt: new Date().toISOString()
-        }
-      ];
+      context.log.warn('Database connection failed, returning empty image list');
 
       context.res = {
         status: 200,
@@ -155,8 +109,8 @@ module.exports = async function (context, req) {
         },
         body: {
           success: true,
-          data: demoImages,
-          count: demoImages.length,
+          data: [],
+          count: 0,
           pagination: {
             limit: limit,
             offset: offset,

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -7,6 +7,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
 import ProjectDetailPage from './pages/ProjectDetailPage';
+import PortfolioPage from './pages/PortfolioPage';
 import ArtDetailPage from './pages/ArtDetailPage';
 import ContactPage from './pages/ContactPage';
 import LoginPage from './pages/LoginPage';
@@ -52,6 +53,7 @@ export default function App() {
         <main className="page-transition loaded">
           <Routes>
             <Route path="/" element={<HomePage />} />
+            <Route path="/category/:slug" element={<PortfolioPage />} />
             <Route path="/project/:slug" element={<ProjectDetailPage />} />
             <Route path="/art/:id" element={<ArtDetailPage />} />
             <Route path="/contact" element={<ContactPage />} />

--- a/web/src/components/CategoryCard.js
+++ b/web/src/components/CategoryCard.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+
+export default function CategoryCard({ category, index }) {
+  return (
+    <motion.div
+      className="project-card"
+      data-aos="fade-up"
+      data-aos-delay={`${index}00`}
+      whileHover={{ y: -8 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Link to={`/category/${category.slug}`} className="project-link">
+        <div className={category.image ? 'project-image' : 'project-image placeholder'}>
+          {category.image && <img src={category.image} alt={category.name} loading="lazy" />}
+        </div>
+        <div className="project-overlay">
+          <h2 className="project-title">{category.name}</h2>
+        </div>
+      </Link>
+    </motion.div>
+  );
+}

--- a/web/src/pages/HomePage.js
+++ b/web/src/pages/HomePage.js
@@ -1,56 +1,42 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import ProjectCard from '../components/ProjectCard';
+import CategoryCard from '../components/CategoryCard';
 import { apiService, handleApiError } from '../services/api';
 
 export default function HomePage() {
-  const [projects, setProjects] = useState([]);
+  const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetchProjects();
+    fetchCategories();
   }, []);
 
-  const fetchProjects = async () => {
+  const fetchCategories = async () => {
     try {
-      const response = await apiService.getProjects();
-      // Transform images to project format for backward compatibility
-      const projectData = Array.isArray(response.data) ? response.data : (response.data.data || []);
-      const transformedProjects = projectData.map(image => ({
-        id: image.id,
-        title: image.title,
-        image: image.thumbnailUrl || image.url,
-        description: image.description
+      const response = await apiService.getCategories();
+      const categoryData = Array.isArray(response.data?.data)
+        ? response.data.data
+        : Array.isArray(response.data)
+        ? response.data
+        : [];
+      const transformed = categoryData.map(cat => ({
+        id: cat.id,
+        name: cat.name,
+        slug: cat.slug,
+        image: cat.coverImageUrl,
+        description: cat.description,
       }));
-      setProjects(transformedProjects);
+      setCategories(transformed);
     } catch (err) {
-      console.error('Failed to fetch projects:', err);
+      console.error('Failed to fetch categories:', err);
       setError(handleApiError(err));
-      
+
       // Fallback to demo data if API not available
-      setProjects([
-        {
-          id: 1,
-          title: 'Digital Art Collection',
-          slug: 'digital-art-collection',
-          image: 'https://picsum.photos/400/300?random=1',
-          description: 'A collection of digital artwork'
-        },
-        {
-          id: 2,
-          title: 'Portrait Series',
-          slug: 'portrait-series',
-          image: 'https://picsum.photos/400/300?random=2',
-          description: 'Contemporary portrait series'
-        },
-        {
-          id: 3,
-          title: 'Abstract Expressions',
-          slug: 'abstract-expressions',
-          image: 'https://picsum.photos/400/300?random=3',
-          description: 'Abstract art expressions'
-        }
+      setCategories([
+        { id: '1', name: 'Tattoo Art', slug: 'tattoo-art', image: null, description: 'Tattoo photography and artwork' },
+        { id: '2', name: 'Art Photography', slug: 'art-photography', image: null, description: 'Artistic photography and visual art' },
+        { id: '3', name: 'Digital Art', slug: 'digital-art', image: null, description: 'Digital artwork and illustrations' },
       ]);
     } finally {
       setLoading(false);
@@ -68,7 +54,7 @@ export default function HomePage() {
   if (error) {
     return (
       <div className="error-message">
-        <h2>Error loading projects</h2>
+        <h2>Error loading categories</h2>
         <p>{error}</p>
       </div>
     );
@@ -104,16 +90,12 @@ export default function HomePage() {
         </div>
       </motion.div>
 
-      {/* Projects Grid */}
+      {/* Categories Grid */}
       <div className="projects-grid">
-        {Array.isArray(projects) && projects.map((project, index) => (
-          <ProjectCard 
-            key={project.id} 
-            project={project} 
-            index={index}
-          />
+        {Array.isArray(categories) && categories.map((cat, index) => (
+          <CategoryCard key={cat.id} category={cat} index={index} />
         ))}
       </div>
     </div>
   );
-} 
+}

--- a/web/src/pages/PortfolioPage.js
+++ b/web/src/pages/PortfolioPage.js
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { Grid, Card } from '../components/ArtCard';
 import { apiService, handleApiError } from '../services/api';
 
 export default function PortfolioPage() {
+  const { slug } = useParams();
+
   const [categories, setCategories] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [images, setImages] = useState([]);
@@ -12,7 +15,7 @@ export default function PortfolioPage() {
 
   useEffect(() => {
     fetchCategories();
-  }, []);
+  }, [slug]);
 
   useEffect(() => {
     if (selectedCategory) {
@@ -27,28 +30,49 @@ export default function PortfolioPage() {
       const response = await apiService.getCategories();
       
       if (response.data && response.data.success && Array.isArray(response.data.data)) {
-        setCategories(response.data.data);
+        const cats = response.data.data;
+        setCategories(cats);
+        if (slug) {
+          const found = cats.find((c) => c.slug === slug);
+          setSelectedCategory(found || null);
+        } else {
+          setSelectedCategory(null);
+        }
       } else {
         console.error('Failed to fetch categories:', response.data?.error || 'Invalid response format');
         setError('Failed to load categories');
         
         // Fallback to demo categories
-        setCategories([
+        const fallbackCats = [
           { id: '1', name: 'Tattoo Art', slug: 'tattoo-art', description: 'Tattoo photography and artwork' },
           { id: '2', name: 'Art Photography', slug: 'art-photography', description: 'Artistic photography and visual art' },
           { id: '3', name: 'Digital Art', slug: 'digital-art', description: 'Digital artwork and illustrations' }
-        ]);
+        ];
+        setCategories(fallbackCats);
+        if (slug) {
+          const found = fallbackCats.find((c) => c.slug === slug);
+          setSelectedCategory(found || null);
+        } else {
+          setSelectedCategory(null);
+        }
       }
     } catch (err) {
       console.error('Failed to fetch categories:', err);
       setError(handleApiError(err));
       
       // Fallback to demo categories
-      setCategories([
+      const fallbackCats = [
         { id: '1', name: 'Tattoo Art', slug: 'tattoo-art', description: 'Tattoo photography and artwork' },
         { id: '2', name: 'Art Photography', slug: 'art-photography', description: 'Artistic photography and visual art' },
         { id: '3', name: 'Digital Art', slug: 'digital-art', description: 'Digital artwork and illustrations' }
-      ]);
+      ];
+      setCategories(fallbackCats);
+      if (slug) {
+        const found = fallbackCats.find((c) => c.slug === slug);
+        setSelectedCategory(found || null);
+      } else {
+        setSelectedCategory(null);
+      }
     }
   };
 
@@ -67,23 +91,12 @@ export default function PortfolioPage() {
         setImages(transformedImages);
       } else {
         console.error('Failed to fetch featured images:', response.data?.error || 'Invalid response format');
-        // Fallback to demo data
-        setImages([
-          { id: '1', title: 'Featured Art 1', image: 'https://picsum.photos/400/400?random=1' },
-          { id: '2', title: 'Featured Art 2', image: 'https://picsum.photos/400/400?random=2' },
-          { id: '3', title: 'Featured Art 3', image: 'https://picsum.photos/400/400?random=3' },
-        ]);
+        setImages([]);
       }
     } catch (err) {
       console.error('Failed to fetch featured images:', err);
       setError(handleApiError(err));
-      
-      // Fallback to demo data
-      setImages([
-        { id: '1', title: 'Featured Art 1', image: 'https://picsum.photos/400/400?random=1' },
-        { id: '2', title: 'Featured Art 2', image: 'https://picsum.photos/400/400?random=2' },
-        { id: '3', title: 'Featured Art 3', image: 'https://picsum.photos/400/400?random=3' },
-      ]);
+      setImages([]);
     } finally {
       setLoading(false);
     }

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -170,6 +170,16 @@ body {
   overflow: hidden;
 }
 
+.project-image.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  background-color: #f5f5f5;
+  color: #666;
+  font-size: 0.9rem;
+}
+
 .project-image img {
   width: 100%;
   height: 300px;
@@ -433,4 +443,34 @@ body {
 /* YouTube gradient */
 .fa-youtube {
   color: #ff0000;
-} 
+}
+
+/* Category navigation */
+.category-navigation {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.category-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.category-btn {
+  border: 1px solid #ddd;
+  background: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.category-btn.active,
+.category-btn:hover {
+  background-color: #ffa600;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- avoid placeholder images for categories
- style category navigation and placeholders
- clean up API fallbacks so no demo images are returned
- handle empty categories gracefully on the frontend

## Testing
- `npm run build` *(fails: package.json missing)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bf7e67f30832e87e98ef0e66a5a4f