### PR TITLE
Set portfolio page as landing page

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -52,7 +52,8 @@ export default function App() {
         />
         <main className="page-transition loaded">
           <Routes>
-            <Route path="/" element={<CategoriesPage />} />
+            <Route path="/" element={<PortfolioPage />} />
+            <Route path="/category" element={<CategoriesPage />} />
             <Route path="/category/:slug" element={<PortfolioPage />} />
             <Route path="/project/:slug" element={<ProjectDetailPage />} />
             <Route path="/art/:id" element={<ArtDetailPage />} />

--- a/web/src/pages/CategoriesPage.js
+++ b/web/src/pages/CategoriesPage.js
@@ -70,24 +70,7 @@ export default function CategoriesPage() {
         transition={{ duration: 0.8 }}
       >
         <h1 className="display-1 text-center">Kihoko Mizuno Jones</h1>
-        <div className="social-links">
-          <a 
-            href="https://www.instagram.com/kihokomizuno/" 
-            target="_blank" 
-            rel="noopener noreferrer"
-            className="social-icon"
-          >
-            <i className="fab fa-instagram"></i>
-          </a>
-          <a 
-            href="https://www.youtube.com/@MizunoJones" 
-            target="_blank" 
-            rel="noopener noreferrer"
-            className="social-icon"
-          >
-            <i className="fab fa-youtube"></i>
-          </a>
-        </div>
+        
       </motion.div>
 
       {/* Categories Grid */}

--- a/web/src/pages/PortfolioPage.js
+++ b/web/src/pages/PortfolioPage.js
@@ -147,13 +147,23 @@ export default function PortfolioPage() {
   return (
     <div className="portfolio-page">
       {/* Category Navigation */}
-      <motion.div 
+      <motion.div
         className="category-navigation"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
       >
         <h1 className="page-title">Portfolio</h1>
+        <div className="social-links">
+          <a
+            href="https://www.instagram.com/kihokomizuno/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="social-icon"
+          >
+            <i className="fab fa-instagram"></i>
+          </a>
+        </div>
         
         <div className="category-buttons">
           <button 


### PR DESCRIPTION
## Summary
- serve `PortfolioPage` at the root URL
- leave the categories page under `/category`
- move Instagram link from `CategoriesPage` to `PortfolioPage`

## Testing
- `npm test` *(fails: package.json missing)*
- `cd api && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685cabf81360832e92e549d776a34c9b