### PR TITLE
Refine about and home pages

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -32,11 +32,14 @@ src/
 │   ├── Footer.js           # Site footer
 │   └── ProjectCard.js      # Individual project cards
 ├── pages/
-│   ├── HomePage.js         # Main portfolio page
+│   ├── HomePage.js        # Minimal splash page
+│   ├── AboutPage.js       # Artist biography
+│   ├── ArtPage.js         # Consolidated artwork gallery
+│   ├── ContactPage.js     # Email contact link
 │   ├── ProjectDetailPage.js # Individual project details
-│   ├── ArtDetailPage.js    # Full-screen art viewer
-│   ├── LoginPage.js        # User login
-│   └── SignupPage.js       # User registration
+│   ├── ArtDetailPage.js   # Full-screen art viewer
+│   ├── LoginPage.js       # User login
+│   └── SignupPage.js      # User registration
 ├── styles/
 │   ├── GlobalStyles.js     # Global styled-components
 │   ├── themes.js           # Light/dark theme definitions

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -5,6 +5,10 @@ import GlobalStyles from './styles/GlobalStyles';
 import { lightTheme, darkTheme } from './styles/themes';
 import Header from './components/Header';
 import Footer from './components/Footer';
+import HomePage from './pages/HomePage';
+import AboutPage from './pages/AboutPage';
+import ArtPage from './pages/ArtPage';
+import ContactPage from './pages/ContactPage';
 import CategoriesPage from './pages/CategoriesPage';
 import ProjectDetailPage from './pages/ProjectDetailPage';
 import PortfolioPage from './pages/PortfolioPage';
@@ -50,7 +54,10 @@ export default function App() {
         />
         <main className="page-transition loaded">
           <Routes>
-            <Route path="/" element={<PortfolioPage />} />
+            <Route path="/" element={<HomePage />} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/art" element={<ArtPage />} />
+            <Route path="/contact" element={<ContactPage />} />
             <Route path="/category" element={<CategoriesPage />} />
             <Route path="/category/:slug" element={<PortfolioPage />} />
             <Route path="/project/:slug" element={<ProjectDetailPage />} />

--- a/web/src/components/ArtCard.js
+++ b/web/src/components/ArtCard.js
@@ -3,38 +3,15 @@ import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 
 export function Grid({ children }) {
-  return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '16px', padding: 16 }}>
-      {children}
-    </div>
-  );
+  return <div className="art-grid">{children}</div>;
 }
 
 export function Card({ item }) {
   return (
-    <motion.div
-      whileHover={{ scale: 1.05 }}
-      style={{ flex: '1 0 calc(33% - 16px)', position: 'relative' }}
-    >
-      <Link to={`/art/${item.id}`} style={{ textDecoration: 'none' }}>
-        <img
-          src={item.image}
-          alt={item.title}
-          style={{ width: '100%', borderRadius: 8 }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            bottom: 8,
-            left: 8,
-            color: '#fff',
-            background: 'rgba(0,0,0,0.5)',
-            padding: '4px 8px',
-            borderRadius: 4,
-          }}
-        >
-          {item.title}
-        </div>
+    <motion.div className="art-card" whileHover={{ scale: 1.05 }}>
+      <Link to={`/art/${item.id}`} className="art-card-link">
+        <img src={item.image} alt={item.title} />
+        <div className="art-card-title">{item.title}</div>
       </Link>
     </motion.div>
   );

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -4,36 +4,11 @@ import { Link, useLocation } from 'react-router-dom';
 export default function Header({ isDarkMode, toggleTheme }) {
   const location = useLocation();
 
-  const isActive = (path) => {
-    return location.pathname === path ? 'nav-link active' : 'nav-link';
-  };
+  const isActive = (path) => (location.pathname === path ? 'nav-link active' : 'nav-link');
+
   return (
     <nav className="navbar navbar-expand-lg">
       <div className="container-fluid px-4 py-3">
-<<<<<<< codex/enable-contact-page-form-submission
-        <div className="d-flex align-items-center justify-content-between w-100">
-          
-          {/* Left Nav */}
-          <div className="d-flex align-items-center">
-            <Link className="navbar-brand fs-4 me-4" to="/">
-              <span className="fw-light">Kihoko</span>
-              <span className="fw-bold"> Mizuno Jones</span>
-            </Link>
-            <ul className="navbar-nav">
-              <li className="nav-item">
-                <Link className={isActive('/')} to="/">Portfolio</Link>
-              </li>
-              <li className="nav-item">
-                <a className="nav-link" href="mailto:kiho@kihoko.com">Contact</a>
-              </li>
-              <li className="nav-item">
-                <a className="nav-link" href="https://shop.kihoko.com" target="_blank" rel="noopener noreferrer">
-                  Shop
-                </a>
-              </li>
-            </ul>
-          </div>
-=======
         <Link className="navbar-brand fs-4 me-4" to="/">
           <span className="fw-light">Kihoko</span>
           <span className="fw-bold"> Mizuno Jones</span>
@@ -52,19 +27,19 @@ export default function Header({ isDarkMode, toggleTheme }) {
           <span className="toggler-line"></span>
         </button>
 
-
         <div className="collapse navbar-collapse" id="navbarSupportedContent">
           <ul className="navbar-nav me-auto mb-2 mb-lg-0">
             <li className="nav-item">
-              <Link className={isActive('/')} to="/">Portfolio</Link>
+              <Link className={isActive('/')} to="/">Home</Link>
             </li>
             <li className="nav-item">
-              <Link className={isActive('/contact')} to="/contact">Contact</Link>
+              <Link className={isActive('/about')} to="/about">About</Link>
             </li>
             <li className="nav-item">
-              <a className="nav-link" href="https://shop.kihoko.com" target="_blank" rel="noopener noreferrer">
-                Shop
-              </a>
+              <Link className={isActive('/art')} to="/art">Art</Link>
+            </li>
+            <li className="nav-item">
+              <a className="nav-link" href="mailto:kiho@kihoko.com">Contact</a>
             </li>
           </ul>
 
@@ -77,7 +52,6 @@ export default function Header({ isDarkMode, toggleTheme }) {
             >
               <i className="fa fa-shopping-cart"></i>
             </a>
->>>>>>> main
 
             <button
               onClick={toggleTheme}

--- a/web/src/pages/AboutPage.js
+++ b/web/src/pages/AboutPage.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function AboutPage() {
+  return (
+    <motion.div
+      className="about-page"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="about-content">
+        <p>
+          Kihoko Mizuno Jones grew up in a small Gifu town famous for its
+          centuries-old ceramic kilns. After immersing herself in ceramic arts at
+          university, she later moved to Los Angeles, where vibrant street
+          culture sparked her career as an illustrator. Now living in Osaka,
+          Japan, Kihoko splits her time between pottery, illustration, and the
+          tattoo studio.
+        </p>
+        <p>
+          Whether you’re looking for an illustration, a one-of-a-kind ceramic
+          piece, or a thoughtfully designed tattoo, she’d love to hear from you.
+        </p>
+      </div>
+    </motion.div>
+  );
+}

--- a/web/src/pages/ArtPage.js
+++ b/web/src/pages/ArtPage.js
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { Grid, Card } from '../components/ArtCard';
+import { apiService, handleApiError } from '../services/api';
+
+export default function ArtPage() {
+  const [images, setImages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchImages();
+  }, []);
+
+  const fetchImages = async () => {
+    setLoading(true);
+    try {
+      const response = await apiService.getAllImages();
+      const data = Array.isArray(response.data?.data)
+        ? response.data.data
+        : Array.isArray(response.data)
+        ? response.data
+        : [];
+      const transformed = data.map((img) => ({
+        id: img.id,
+        title: img.title,
+        image: img.thumbnailUrl || img.url,
+        category: img.categoryId,
+      }));
+      setImages(transformed);
+    } catch (err) {
+      console.error('Failed to fetch images:', err);
+      setError(handleApiError(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading && !images.length) {
+    return (
+      <div className="loading-spinner">
+        <div>Beautiful Artwork Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="portfolio-page">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.6 }}
+      >
+        {error && (
+          <div className="error-message">
+            <p>{error}</p>
+          </div>
+        )}
+        {images.length > 0 ? (
+          <Grid>
+            {images.map((item, index) => (
+              <motion.div
+                key={item.id}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: index * 0.1 }}
+              >
+                <Card item={item} />
+              </motion.div>
+            ))}
+          </Grid>
+        ) : (
+          !loading && (
+            <div className="no-images">
+              <p>No images found.</p>
+            </div>
+          )
+        )}
+      </motion.div>
+    </div>
+  );
+}

--- a/web/src/pages/ContactPage.js
+++ b/web/src/pages/ContactPage.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function ContactPage() {
+  return (
+    <motion.div
+      className="contact-page"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
+      <h1>Get in Touch</h1>
+      <p>
+        <a href="mailto:kiho@kihoko.com">kiho@kihoko.com</a>
+      </p>
+    </motion.div>
+  );
+}

--- a/web/src/pages/HomePage.js
+++ b/web/src/pages/HomePage.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+
+const bgUrl = 'https://live.staticflickr.com/65535/54614150947_63ef8bf185_b.jpg';
+
+export default function HomePage() {
+  return (
+    <motion.div
+      className="home-page"
+      style={{ backgroundImage: `url(${bgUrl})` }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+    >
+      <div className="home-links">
+        <Link to="/about" className="btn btn-outline-light me-2">
+          About
+        </Link>
+        <Link to="/art" className="btn btn-outline-light me-2">
+          Art
+        </Link>
+        <a href="mailto:kiho@kihoko.com" className="btn btn-outline-light">
+          Contact
+        </a>
+      </div>
+    </motion.div>
+  );
+}

--- a/web/src/styles/style.css
+++ b/web/src/styles/style.css
@@ -510,3 +510,92 @@ body {
   color: #fff;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
+
+
+/* About Page */
+.about-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 3rem 2rem;
+  color: #333;
+}
+
+.about-content {
+  max-width: 600px;
+  margin: 0 auto;
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+
+/* Contact Page */
+.contact-page {
+  text-align: center;
+  padding: 4rem 2rem;
+}
+
+/* Art Page Grid */
+.art-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.art-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  aspect-ratio: 1 / 1;
+}
+
+.art-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.art-card-title {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  padding: 4px 8px;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+/* Home Page */
+.home-page {
+  background-size: cover;
+  background-position: center;
+  min-height: 100vh;
+  position: relative;
+}
+
+.home-links {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 1.5rem;
+}
+
+.home-links a {
+  margin-right: 0.5rem;
+}
+
+@media (max-width: 768px) {
+  .art-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .art-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak project structure docs for new Home, About, Art, and Contact pages
- add About link to the homepage splash navigation
- remove background image from About page and style text area cleanly
- adjust styles for the new About layout

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d36bbf388832ea97c6f15ad9fba2e